### PR TITLE
[1/2] core: Add support for fake signatures, enabled by developer setting

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5350,6 +5350,15 @@ public final class Settings {
         public static final String INSTALL_NON_MARKET_APPS = "install_non_market_apps";
 
         /**
+         * Whether applications can fake a signature.
+         *
+         * <p>1 = permit apps to fake signature
+         * <p>0 = disable this feature
+         * @hide
+         */
+        public static final String ALLOW_SIGNATURE_FAKE = "allow_signature_fake";
+
+        /**
          * Comma-separated list of location providers that activities may access. Do not rely on
          * this value being present in settings.db or on ContentObserver notifications on the
          * corresponding Uri.


### PR DESCRIPTION
Gerrit source: https://gerrit.omnirom.org/c/android_frameworks_base/+/14898

Manually picked Settings.java commit for Signature Spoofing toggle

Thanks to Omni ROM devs for Implementation.